### PR TITLE
Tweak elements for mobile experience

### DIFF
--- a/static/base.html
+++ b/static/base.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, user-scalable=no">
     <title>{{ .Title }}</title>
     <link rel="stylesheet" type="text/css" href="/static/css/hack/hack.css">
     <link rel="stylesheet" type="text/css" href="/static/css/site.css">

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -302,7 +302,6 @@ input[type=text] {
 }
 
 #messages {
-    min-height: 15em;
     color: var(--var-message-color);
     overflow-y: scroll;
     border: var(--var-border);


### PR DESCRIPTION
This commit forces a device-width sized viewport, which makes for a much
more usable chat experience on mobile devices. A chat element min-size
is also removed to avoid screen overflow on mobile devices.