### PR TITLE
Bans was present twice in the example settings.json file.

### DIFF
--- a/settings_example.json
+++ b/settings_example.json
@@ -6,7 +6,6 @@
 	"StreamKey": "ALongStreamKey",
 	"ListenAddress": ":8089",
 	"ApprovedEmotes": null,
-	"Bans": [],
 	"LogLevel": "debug",
 	"LogFile": "thelog.log",
 	"RateLimitChat": 1,


### PR DESCRIPTION
Removing the duplicate "Bans" attribute. 