### PR TITLE
emotes: send OAuth secret token to Twitch when fetching emotes

### DIFF
--- a/emotes.go
+++ b/emotes.go
@@ -168,6 +168,7 @@ func getUserIDs(names []string) []TwitchUser {
 		log.Fatalln("Error generating new request:", err)
 	}
 	request.Header.Set("Client-ID", settings.TwitchClientID)
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", settings.TwitchClientSecret))
 
 	client := http.Client{}
 	resp, err := client.Do(request)

--- a/settings.go
+++ b/settings.go
@@ -23,25 +23,26 @@ type Settings struct {
 	cmdLineKey string // stream key from the command line
 
 	// Saved settings
-	AdminPassword   string
-	ApprovedEmotes  []string // list of channels that have been approved for emote use.  Global emotes are always "approved".
-	Bans            []BanInfo
-	LetThemLurk     bool // whether or not to announce users joining/leaving chat
-	ListenAddress   string
-	LogFile         string
-	LogLevel        common.LogLevel
-	MaxMessageCount int
-	NewPin          bool   // Auto generate a new pin on start.  Overwrites RoomAccessPin if set.
-	PageTitle       string // primary value for the page <title> element
-	RegenAdminPass  bool // regenerate admin password on start?
-	RoomAccess      AccessMode
-	RoomAccessPin   string // The current pin
-	SessionKey      string   // key for session data
-	StreamKey       string
-	StreamStats     bool
-	TitleLength     int // maximum length of the title that can be set with the /playing
-	TwitchClientID  string   // client id from twitch developers portal
-	WrappedEmotesOnly bool // only allow "wrapped" emotes.  eg :Kappa: and [Kappa] but not Kappa
+	AdminPassword      string
+	ApprovedEmotes     []string // list of channels that have been approved for emote use.  Global emotes are always "approved".
+	Bans               []BanInfo
+	LetThemLurk        bool // whether or not to announce users joining/leaving chat
+	ListenAddress      string
+	LogFile            string
+	LogLevel           common.LogLevel
+	MaxMessageCount    int
+	NewPin             bool   // Auto generate a new pin on start.  Overwrites RoomAccessPin if set.
+	PageTitle          string // primary value for the page <title> element
+	RegenAdminPass     bool   // regenerate admin password on start?
+	RoomAccess         AccessMode
+	RoomAccessPin      string // The current pin
+	SessionKey         string // key for session data
+	StreamKey          string
+	StreamStats        bool
+	TitleLength        int    // maximum length of the title that can be set with the /playing
+	TwitchClientID     string // client id from twitch developers portal
+	TwitchClientSecret string // OAuth from twitch developers portal: https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow
+	WrappedEmotesOnly  bool   // only allow "wrapped" emotes.  eg :Kappa: and [Kappa] but not Kappa
 
 	// Rate limiting stuff, in seconds
 	RateLimitChat      time.Duration

--- a/settings_example.json
+++ b/settings_example.json
@@ -17,5 +17,7 @@
 	"RegenAdminPass": true,
 	"StreamKey": "ALongStreamKey",
 	"TitleLength": 50,
+	"TwitchClientID": "",
+	"TwitchClientSecret": "",
 	"WrappedEmotesOnly": false
 }


### PR DESCRIPTION
As of last month, requests made to the Twitch Helix API require an OAuth token
as well as the Client ID: https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916