### PR TITLE
emotes: display in grid instead of one per line

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -110,16 +110,17 @@ input[type=text] {
 }
 
 #emotesbody {
-    color: var(--var-message-color);
+  color: var(--var-message-color);
 }
 
 .emotedef {
-    display: flex;
-    flex-direction: row;
+  float: left;
+  padding: 5px 5px 15px 5px;
 }
 
-.emotedef div {
-    padding: 5px;
+.emotedef img {
+  height: 112px;
+  width: 112px;
 }
 
 .notice {


### PR DESCRIPTION
The flexbox was claiming a row for each emote.  If we change to floats we get this instead:
<img width="652" alt="Screen Shot 2020-06-07 at 2 37 51 PM" src="https://user-images.githubusercontent.com/985416/83980702-a39d2100-a8cc-11ea-970e-46c339d790b1.png">
