### PR TITLE
add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*~
+settings.json
+static/subscriber.json
+subscribers.json


### PR DESCRIPTION
Just in case a built image is ever pushed to a registry, scrub any configs in `settings.json` etc.