### PR TITLE
Changed settings.go to allow disabling the ratelimits.

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -103,34 +103,36 @@ func LoadSettings(filename string) (*Settings, error) {
 		}
 	}
 
+	// Set to -1 to reset
 	if s.RateLimitChat == -1 {
-		s.RateLimitChat = 0
-	} else if s.RateLimitChat <= 0 {
 		s.RateLimitChat = 1
+	} else if s.RateLimitChat < 0 {
+		s.RateLimitChat = 0
 	}
 
 	if s.RateLimitNick == -1 {
-		s.RateLimitNick = 0
-	} else if s.RateLimitNick <= 0 {
 		s.RateLimitNick = 300
+	} else if s.RateLimitNick < 0 {
+		s.RateLimitNick = 0
 	}
 
 	if s.RateLimitColor == -1 {
-		s.RateLimitColor = 0
-	} else if s.RateLimitColor <= 0 {
 		s.RateLimitColor = 60
+	} else if s.RateLimitColor < 0 {
+		s.RateLimitColor = 0
 	}
 
 	if s.RateLimitAuth == -1 {
-		s.RateLimitAuth = 0
-	} else if s.RateLimitAuth <= 0 {
 		s.RateLimitAuth = 5
+	} else if s.RateLimitAuth < 0 {
+		common.LogInfoln("It's not recommended to disable the authentication rate limit.")
+		s.RateLimitAuth = 0
 	}
 
 	if s.RateLimitDuplicate == -1 {
-		s.RateLimitDuplicate = 0
-	} else if s.RateLimitDuplicate <= 0 {
 		s.RateLimitDuplicate = 30
+	} else if s.RateLimitDuplicate < 0 {
+		s.RateLimitDuplicate = 0
 	}
 
 	if s.WrappedEmotesOnly {


### PR DESCRIPTION
Before, the settings parser would automatically reset the ratelimit
times to the default if you set them to zero. You could get around
this by setting the ratelimits to -1, but then the parser would
immediately set them to zero and write to disk. On next launch,
the parser would read the zeros and then reset the values to
default, so you would have to modify your ratelimits every
launch.