### PR TITLE
Add unlocks to error cases in handlers::handlePublish()

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -363,16 +363,19 @@ func handlePublish(conn *rtmp.Conn) {
 
 	if len(urlParts) > 2 {
 		common.LogErrorln("Extra garbage after stream key")
+		l.Unlock()
 		return
 	}
 
 	if len(urlParts) != 2 {
 		common.LogErrorln("Missing stream key")
+		l.Unlock()
 		return
 	}
 
 	if urlParts[1] != settings.GetStreamKey() {
 		common.LogErrorln("Stream key is incorrect.  Denying stream.")
+		l.Unlock()
 		return //If key not match, deny stream
 	}
 


### PR DESCRIPTION
In handlers::handlePublish(), the mutex for the rtmp stream is locked at the beginning of the function. The previous implementation checked for error cases (e.g. incorrect stream key), logging and immediately returning if an error case was found. The mutex, however, was not unlocked, leading to the server effectively 'freezing' as other interactions try and lock that mutex. 
This MR adds mutex unlocks in each error case to ensure that the server continues to function in the event of a recoverable error.