### PR TITLE
Fix docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # ------ building mmovienight from source ------
 #
 
-FROM golang:1.13-alpine AS build
+FROM golang:1.16-alpine AS build
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN apk add alpine-sdk
 
 COPY . .
 
-RUN make
+RUN make docker
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 TAGS= 
 
-.PHONY: fmt vet get clean dev setdev test ServerMovieNight 
+.PHONY: fmt vet get clean dev setdev test docker ServerMovieNight 
 
 all: fmt vet test MovieNight settings.json 
 
@@ -43,6 +43,8 @@ vet:
 
 test: 
 	go$(GO_VERSION) test $(TAGS) ./... 
+
+docker: fmt vet MovieNight settings.json 
 
 # Do not put settings_example.json here as a prereq to avoid overwriting
 # the settings if the example is updated.


### PR DESCRIPTION
I updated the image version since the project was using go 1.16 and the Dockerfile was still using the 1.13 one, which resulted in an error during build

```bash
#0 3.380 build github.com/zorchenhimer/MovieNight: cannot load embed: malformed module path "embed": missing dot in first path element
```

Then I had problems starting the docker due to playwright not being able to find node executables and/or not downloading browsers correctly

```bash
...
#0 18.15 [INFO] 2022/11/02 23:39:16 HTTP server listening on:  :8089
#0 18.15 [INFO] 2022/11/02 23:39:16 RTMP server listening on:  :1935
#0 18.15 [INFO] 2022/11/02 23:39:16 RoomAccess:  open
#0 18.15 [INFO] 2022/11/02 23:39:16 RoomAccessPin:
#0 18.15 [INFO] 2022/11/02 23:39:16 Startup took 3.263446ms
#0 18.15 2022/11/02 23:39:17 Downloading driver to /root/.cache/ms-playwright-go/1.20.0-beta-1647057403000
#0 18.15 2022/11/02 23:39:19 Downloaded driver successfully
#0 18.15 2022/11/02 23:39:19 Downloading browsers...
#0 18.15 /root/.cache/ms-playwright-go/1.20.0-beta-1647057403000/playwright.sh: line 3: /root/.cache/ms-playwright-go/1.20.0-beta-1647057403000/node: not found
#0 18.15 could not install playwright: could not install driver: could not install browsers: could not install browsers: exit status 127
#0 18.15 FAIL	github.com/zorchenhimer/MovieNight	2.864s
#0 18.15 ok  	github.com/zorchenhimer/MovieNight/common	0.009s
#0 18.15 ok  	github.com/zorchenhimer/MovieNight/files	0.009s
#0 18.15 FAIL
#0 18.17 make: *** [Makefile:45: test] Error 1
...
```

Since running tests in the docker build is not really necessary, I created a custom entry in the Makefile equal to make all, just without running the tests.

Then, just calling `make docker` in the Dockerfile instead of `make`

This small changes allow to correctly run the docker via compose.


