### PR TITLE
using correct settings.json path in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,11 @@ docker build -t movienight .
 Run the image once it's built:
 
 ```shell
-docker run -d -p 8089:8089 -p 1935:1935 [-v ./settings.json:/config/settings.json] movienight
+# with default settings file (this uses the settings_example.json config file)
+docker run -d -p 8089:8089 -p 1935:1935 movienight
+
+# using a custom settings file
+docker run -d -p 8089:8089 -p 1935:1935 -v ./settings.json:/data/config/settings.json movienight
 ```
 
 Explanation:


### PR DESCRIPTION
so, I wanted to run the service today with the docker commands in the readme and noticed that the settings.json path was `/config/settings.json` instead of `/data/config/settings.json`, so I fixed that here

I split it up in 2 commands, one with the optional settings.json parameter and one without